### PR TITLE
Fix white mode background and fonts

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,6 +1,9 @@
+html, body {
+  font-family: 'Inter', sans-serif;
+}
+
 body {
-font-family: 'Inter', sans-serif;
-background-color: #f8f9fa;
+  background-color: #ffffff;
 }
 .pillar-title {
 font-size: 2.5rem;

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <meta http-equiv="Expires" content="0">
     <link rel="stylesheet" href="css/styles.css?v=1">
 </head>
-<body class="bg-gray-100 dark:bg-gray-900 dark:text-gray-100">
+<body class="bg-white dark:bg-gray-900 dark:text-gray-100">
     <div data-include="partials/header.html"></div>
     <main class="container mx-auto p-4 md:p-8">
         <div data-include="partials/hero.html"></div>


### PR DESCRIPTION
## Summary
- default light mode uses a pure white background
- ensure Inter font applies to html and body

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685fc8b7b46c832e9fb49e56cf727c8c