### PR TITLE
Improve responsive navigation

### DIFF
--- a/modules/header.html
+++ b/modules/header.html
@@ -2,7 +2,12 @@
         <nav class="container mx-auto px-6 py-3">
             <div class="flex items-center justify-between">
                 <div class="text-xl font-bold text-gray-800">The CTO's Strategic Atlas</div>
-                <div class="hidden md:flex space-x-4 text-sm font-semibold">
+                <button id="menu-btn" class="md:hidden focus:outline-none" aria-label="Toggle navigation">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                    </svg>
+                </button>
+                <div id="nav-links" class="hidden md:flex flex-col md:flex-row md:items-center space-y-2 md:space-y-0 md:space-x-4 text-sm font-semibold">
                     <a href="#pillar1" class="text-gray-600 hover:text-red-500">Leadership & Innovation</a>
                     <a href="#pillar2" class="text-gray-600 hover:text-red-500">Architecture & Dev</a>
                     <a href="#pillar3" class="text-gray-600 hover:text-red-500">Management & Gov</a>

--- a/modules/script.js
+++ b/modules/script.js
@@ -256,3 +256,12 @@ Keep the language clear, strategic, and direct.`;
                 generateBtn.classList.remove('opacity-50');
             }
         });
+
+        // Mobile menu toggle
+        const menuBtn = document.getElementById('menu-btn');
+        const navLinks = document.getElementById('nav-links');
+        if (menuBtn && navLinks) {
+            menuBtn.addEventListener('click', () => {
+                navLinks.classList.toggle('hidden');
+            });
+        }


### PR DESCRIPTION
## Summary
- add hamburger button for small screens
- handle mobile navigation toggle in script

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685fe5be73a8832eacb6c06e9b468bfd